### PR TITLE
Fix update between tabs

### DIFF
--- a/src/containers/Popup.tsx
+++ b/src/containers/Popup.tsx
@@ -93,9 +93,8 @@ export default class Popup extends Component {
             chrome.tabs.query({active: true, currentWindow: true}, (tabs: ChromeTab[]) => {
                 chrome.tabs.update(tabs[0].id, {url: tabs[0].url});
             });
-        } else {
-            this.updateState();
         }
+        this.updateState();
     }
 
     toggleEnable = () => {


### PR DESCRIPTION
I found a small bug when testing out #27.

In the main tab, if I use the toggle domain button and then go to the whitelist tab the change is not reflected until I close and reopen the extension popup.

I've verified this change fixes the bug, but not sure if it would affect things elsewhere.