### PR TITLE
Quality of life changes: do reload at better times

### DIFF
--- a/src/containers/Popup.tsx
+++ b/src/containers/Popup.tsx
@@ -147,7 +147,8 @@ export default class Popup extends Component {
         chrome.tabs.query({active: true, currentWindow: true}, (tabs: ChromeTab[]) => {
             chrome.storage.sync.get({
               isSummarizerEnabled: false,
-            }, ({shouldReload}) => {
+            }, ({isSummarizerEnabled}) => {
+                const shouldReload = isSummarizerEnabled;
                 const url = new URL(tabs[0].url!);
                 if (this.state.hasDomain) {
                     this.addDomain(url.hostname, shouldReload);

--- a/src/containers/Popup.tsx
+++ b/src/containers/Popup.tsx
@@ -102,6 +102,10 @@ export default class Popup extends Component {
         });
         chrome.storage.sync.set({
             isSummarizerEnabled: enabled,
+        }, () => {
+            if (this.state.hasDomain) {
+                this.refreshOrUpdate(true);
+            }
         });
     }
 
@@ -141,12 +145,16 @@ export default class Popup extends Component {
             hasDomain,
         });
         chrome.tabs.query({active: true, currentWindow: true}, (tabs: ChromeTab[]) => {
-            const url = new URL(tabs[0].url!);
-            if (this.state.hasDomain) {
-                this.addDomain(url.hostname, true);
-            } else {
-                this.removeDomain(url.hostname, true);
-            }
+            chrome.storage.sync.get({
+              isSummarizerEnabled: false,
+            }, ({shouldReload}) => {
+                const url = new URL(tabs[0].url!);
+                if (this.state.hasDomain) {
+                    this.addDomain(url.hostname, shouldReload);
+                } else {
+                    this.removeDomain(url.hostname, shouldReload);
+                }
+            });
         });
     }
 


### PR DESCRIPTION
Theres 2 cases where I think this provides better QOL:
* when enabling/disabling the global toggle _and_ the site is in the whitelist, reload the page
* when adding/removing domains from the whitelist _and_ the global toggle is disabled, don't reload the page