### PR TITLE
Change API call location

### DIFF
--- a/public/bg/performHighlighting.js
+++ b/public/bg/performHighlighting.js
@@ -1,6 +1,6 @@
 /*global chrome*/
 const apiCall = (userEmail, userId, title, text, lang) => {
-  return fetch("https://jent.ly/api/summarize", {
+  return fetch("https://api.jent.ly/v1/summarize", {
     method: "POST",
     headers: {
       "Accept": "application/json",


### PR DESCRIPTION
Since we're changing `jent.ly` to be the marketing site.