### PR TITLE
Add redirect to getting started page on install

### DIFF
--- a/public/bg/showPageAction.js
+++ b/public/bg/showPageAction.js
@@ -10,5 +10,17 @@ function checkForValidUrl(tabId, changeInfo, tab) {
   }
 };
 
+function redirectToGettingStartedPage() {
+  chrome.tabs.create({
+    url: "https://jent.ly/gettingstarted/",
+    active: true
+  });
+
+  return false;
+};
+
 // Listen for any changes to the URL of any tab.
 chrome.tabs.onUpdated.addListener(checkForValidUrl);
+
+// Listen for when the user installs the extension.
+chrome.runtime.onInstalled.addListener(redirectToGettingStartedPage);


### PR DESCRIPTION
Tested that it works.

FYI, when developing, "load unpacked" does the same as installing.